### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/staticfiles/django_htmx/htmx.js
+++ b/staticfiles/django_htmx/htmx.js
@@ -853,6 +853,20 @@ var htmx = (function() {
     return path
   }
 
+  /**
+   * @param {string} path
+   * @returns {boolean}
+   */
+  function isSafeHistoryPath(path) {
+    try {
+      const normalized = normalizePath(path)
+      const parsed = new URL(normalized, location.origin)
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    } catch (e) {
+      return false
+    }
+  }
+
   //= =========================================================================================
   // public API
   //= =========================================================================================
@@ -3215,12 +3229,31 @@ var htmx = (function() {
       return null
     }
 
-    url = normalizePath(url)
+    try {
+      url = normalizePath(url)
+    } catch (e) {
+      return null
+    }
+
+    if (!isSafeHistoryPath(url)) {
+      return null
+    }
 
     const historyCache = parseJSON(sessionStorage.getItem('htmx-history-cache')) || []
+    if (!Array.isArray(historyCache)) {
+      return null
+    }
+
     for (let i = 0; i < historyCache.length; i++) {
-      if (historyCache[i].url === url) {
-        return historyCache[i]
+      const item = historyCache[i]
+      if (!item || typeof item.url !== 'string' || typeof item.content !== 'string' || typeof item.title !== 'string') {
+        continue
+      }
+      if (!isSafeHistoryPath(item.url)) {
+        continue
+      }
+      if (item.url === url) {
+        return item
       }
     }
     return null


### PR DESCRIPTION
Potential fix for [https://github.com/heriberto-codes/cThink/security/code-scanning/3](https://github.com/heriberto-codes/cThink/security/code-scanning/3)

Best fix: validate history cache entries before using them for HTML swap, and reject cached entries when URL/path fields are unsafe. This preserves existing functionality for normal paths while blocking attacker-crafted cache poisoning through querystring-controlled keys.

In `staticfiles/django_htmx/htmx.js`, add a small URL/path safety validator and enforce it in `getCachedHistory(url)`:

- Normalize path inside a guarded try/catch (reject malformed URL input).
- Ensure parsed cache is an array of objects with expected primitive types.
- Only return items whose `url` exactly matches normalized requested URL **and** passes safety checks (`http:`/`https:` only, no `javascript:`/`data:`), plus `content` and `title` are strings.
- Return `null` for invalid entries so tainted cache content never reaches `swap()`/`parseHTML()`.

This is the minimal, behavior-preserving hardening in shown code, and addresses all listed variants because all taint paths converge through history cache read/use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
